### PR TITLE
Limit permissions to only github.com

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -5,10 +5,10 @@
   "content_scripts": [ {
     "css": [ "iso.css" ],
     "js": [ "jquery.min.js", "obelisk.min.js", "iso.js" ],
-    "matches": [ "http://*/*", "https://*/*" ]
+    "matches": [ "http://github.com/*", "https://github.com/*" ]
   }],
   "permissions": [
-    "storage"
+    "storage", "http://github.com/*", "https://github.com/*"
   ],
   "icons" : {
     "48" : "icon-48.png",


### PR DESCRIPTION
This removes the scary warning that Chrome gives about the plugin being able to access data on _all_ webpages a user visits.