### PR TITLE
Changed .ic-stats-count back to font-weight: bold in Chrome

### DIFF
--- a/chrome/iso.css
+++ b/chrome/iso.css
@@ -137,7 +137,7 @@
 .ic-stats-count {
   display: block;
   font-size: 32px;
-  font-weight: 600;
+  font-weight: bold;
   line-height: 1;
   color: #1e6823;
 }


### PR DESCRIPTION
It just looks a lot better that way (and the Firefox and Safari versions are still bolded as well).