### PR TITLE
Minor Fix for Longest Streak with No Commit History

### DIFF
--- a/src/iso.coffee
+++ b/src/iso.coffee
@@ -225,9 +225,12 @@ class Iso
       dateBest = 'No activity found'
 
     # Longest streak
-    longestStreakStart = this.formatDateString longestStreakStart, dateOptions
-    longestStreakEnd   = this.formatDateString longestStreakEnd, dateOptions
-    datesLongest       = longestStreakStart + " — " + longestStreakEnd
+    if streakLongest > 0
+      longestStreakStart = this.formatDateString longestStreakStart, dateOptions
+      longestStreakEnd   = this.formatDateString longestStreakEnd, dateOptions
+      datesLongest       = longestStreakStart + " — " + longestStreakEnd
+    else
+      datesLongest = "No longest streak"
 
     this.renderTopStats(countTotal, averageCount, datesTotal, maxCount, dateBest)
     this.renderBottomStats(streakLongest, datesLongest, streakCurrent, datesCurrent)


### PR DESCRIPTION
This pull request addresses a very minor issue that can be seen when a user has no commit history. The start and end date for the streak are shown as `null - null`. See the screenshot below.

![image](https://user-images.githubusercontent.com/22732449/47825606-aaa79900-dd51-11e8-97ee-e6dc612e55cd.png)

@jasonlong This is my first time contributing to your project, and I'm not sure if you want the source transpiled to js for Chrome, Firefox and Safari for every PR. I can do this if needed. Interested in hearing your feedback as well.