### PR TITLE
Run at document_idle for firefox

### DIFF
--- a/firefox/isometric-contributions/manifest.json
+++ b/firefox/isometric-contributions/manifest.json
@@ -5,8 +5,7 @@
   "content_scripts": [ {
     "css": [ "iso.css" ],
     "js": [ "jquery.min.js", "obelisk.min.js", "iso.js" ],
-    "matches": [ "http://*/*", "https://*/*" ],
-    "run_at": "document_start"
+    "matches": [ "http://*/*", "https://*/*" ]
   }],
   "permissions": [
     "storage"


### PR DESCRIPTION
Fix #100
Need to change this to `"run_at": "document_idle"`, but since `"document_idle"` is the default value for `"run_at"` omitting the line completely works too.
https://github.com/jasonlong/isometric-contributions/blob/0f3b85566ba5538341f45c669e04e54b09834524/firefox/isometric-contributions/manifest.json#L9
Also packaging firefox extension via `xpinstall` has been deprecated. You only need to [put all the files into a `.zip`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Package_your_extension_) now