### PR TITLE
Update iso.css for firefox

### DIFF
--- a/firefox/isometric-contributions/iso.css
+++ b/firefox/isometric-contributions/iso.css
@@ -108,12 +108,12 @@
 }
 
 .ic-stats-top {
-  top: 20px;
-  left: 390px;
+  top: 8px;
+  right: 20px;
 }
 
 .ic-stats-bottom {
-  top: 265px;
+  top: 225px;
   left: 20px;
 }
 
@@ -127,7 +127,7 @@
 
 .ic-stats-label {
   display: table-cell;
-  padding-bottom: 20px;
+  padding-bottom: 12px;
   font-size: 14px;
   color: #777;
   text-align: right;
@@ -136,17 +136,18 @@
 
 .ic-stats-count {
   display: block;
-  font-size: 40px;
-  font-weight: bold;
-  line-height: 38px;
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1;
   color: #1e6823;
 }
 
 .ic-stats-meta {
   display: table-cell;
-  padding-bottom: 20px;
+  padding-bottom: 12px;
   padding-left: 8px;
   text-align: left;
+  line-height: 1.2;
   vertical-align: bottom;
 }
 
@@ -155,23 +156,25 @@
 }
 
 .ic-stats-average {
+  font-size: 12px;
   font-weight: bold;
   color: #24292e;
 }
 
 .ic-stats-unit {
   display: block;
-  font-size: 15px;
+  font-size: 14px;
 }
 
 .ic-stats-date {
   display: block;
   color: #999;
+  font-size: 12px;
 }
 
 .ic-footer {
   position: absolute;
-  top: 450px;
+  top: 380px;
   left: 20px;
   font-size: 11px;
   color: #999;


### PR DESCRIPTION
There was some issue with the firefox extension (no show/hide normal chart toggle, screenshot included) because the last commit to `iso.css` 9c89e59bf0efb3caf116eca5999b70b70768f174 wasn't applied to firefox.

Thanks for making this extension btw. It's really cool!

<img width="640" alt="Screen Shot 2019-03-21 at 6 51 11 PM" src="https://user-images.githubusercontent.com/6521018/54747674-836f3c80-4c0a-11e9-836a-663d0daf1922.png">