### PR TITLE
Re-render Chart When Switching Date Ranges

### DIFF
--- a/src/iso.coffee
+++ b/src/iso.coffee
@@ -379,11 +379,6 @@ if document.querySelector '.js-calendar-graph'
   # load iso graph when the page first load
   loadIso()
 
-  # load iso graph when pjax request load (switch between tabs)
-  document.addEventListener 'pjax:success', () ->
-    console.log 'pjax:success'
-    loadIso()
-
   # load iso graph when contribution graph upload (change time)
   targetNode = document.getElementById 'js-pjax-container'
   config = { attributes: false, childList: true, subtree: true }
@@ -391,7 +386,7 @@ if document.querySelector '.js-calendar-graph'
     for mutation in mutationsList
       if mutation.type == 'childList'
         for node in mutation.addedNodes
-          if ($ node).hasClass 'js-contribution-graph'
+          if ($ node).hasClass 'js-yearly-contributions'
             loadIso()
   observer = new MutationObserver(callback)
   observer.observe(targetNode, config)


### PR DESCRIPTION
Fixes #102 

When selecting a new date range, re-render the chart for the new commit
history data. It appears as though it was once working, but changes on
the GitHub side required changes to the extension to handle it.

The event handler for 'pjax:success' was no longer being invoked and would
not re-render the chart, so it could be safely removed.