### PR TITLE
Fix host_permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub Isometric Contributions",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Renders an isometric pixel view of GitHub contribution graphs.",
   "content_scripts": [
     {
@@ -11,7 +11,7 @@
     }
   ],
   "permissions": ["storage", "contextMenus", "activeTab"],
-  "host_permissions": ["http://*/*", "https://*/*"],
+  "host_permissions": ["https://github.com/"],
   "icons": {
     "48": "icon-48.png",
     "128": "icon-128.png"


### PR DESCRIPTION
Fixes #191 

I misinterpreted [this part](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#host-permissions) of the manifest v3 upgrade which caused the extension to request permission on all sites. Hopefully this change restores the proper behavior.