### PR TITLE
Add support for new `<tool-tip>` markup

### DIFF
--- a/src/iso.js
+++ b/src/iso.js
@@ -167,26 +167,28 @@ const loadStats = () => {
   let currentStreakStart = null
   let currentStreakEnd = null
 
-  const days = [...document.querySelectorAll('.js-calendar-graph-table tbody td.ContributionCalendar-day')].map((d) => {
-    return {
-      date: new Date(d.dataset.date),
-      week: d.dataset.ix,
-      color: getSquareColor(d),
-      tid: d.getAttribute('aria-labelledby')
+  const dayNodes = [...document.querySelectorAll('.js-calendar-graph-table tbody td.ContributionCalendar-day')].map(
+    (d) => {
+      return {
+        date: new Date(d.dataset.date),
+        week: d.dataset.ix,
+        color: getSquareColor(d),
+        tid: d.getAttribute('aria-labelledby')
+      }
     }
-  })
+  )
 
-  const tooltips = [...document.querySelectorAll('.js-calendar-graph tool-tip')].map((t) => {
+  const tooltipNodes = [...document.querySelectorAll('.js-calendar-graph tool-tip')].map((t) => {
     return {
       tid: t.id,
       count: getCountFromNode(t)
     }
   })
 
-  const data = days.map((d) => {
+  const data = dayNodes.map((d) => {
     return {
       ...d,
-      ...(tooltips.find((t) => t.tid === d.tid) || {})
+      ...tooltipNodes.find((t) => t.tid === d.tid)
     }
   })
 

--- a/src/iso.js
+++ b/src/iso.js
@@ -167,12 +167,26 @@ const loadStats = () => {
   let currentStreakStart = null
   let currentStreakEnd = null
 
-  const data = [...document.querySelectorAll('.js-calendar-graph-table tbody td.ContributionCalendar-day')].map((d) => {
+  const days = [...document.querySelectorAll('.js-calendar-graph-table tbody td.ContributionCalendar-day')].map((d) => {
     return {
-      count: getCountFromNode(d),
       date: new Date(d.dataset.date),
       week: d.dataset.ix,
-      color: getSquareColor(d)
+      color: getSquareColor(d),
+      tid: d.getAttribute('aria-labelledby')
+    }
+  })
+
+  const tooltips = [...document.querySelectorAll('.js-calendar-graph tool-tip')].map((t) => {
+    return {
+      tid: t.id,
+      count: getCountFromNode(t)
+    }
+  })
+
+  const data = days.map((d) => {
+    return {
+      ...d,
+      ...(tooltips.find((t) => t.tid === d.tid) || {})
     }
   })
 

--- a/src/manifest-v2.json
+++ b/src/manifest-v2.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "GitHub Isometric Contributions",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Renders an isometric pixel view of GitHub contribution graphs.",
   "content_scripts": [
     {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GitHub Isometric Contributions",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Renders an isometric pixel view of GitHub contribution graphs.",
   "content_scripts": [
     {
@@ -15,10 +15,5 @@
   "icons": {
     "48": "icon-48.png",
     "128": "icon-128.png"
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "isometric-contributions@jasonlong.me"
-    }
   }
 }


### PR DESCRIPTION
Fixes the data scraping once again to support GitHub's latest markup changes. The daily contribution count is now contained in a separate `<tool-tip>` element. This change merges all of the days with all of the tooltips to get the expected data structure.

Fixes #297 