### PR TITLE
Handle async contribution graph loading

### DIFF
--- a/src/iso.js
+++ b/src/iso.js
@@ -453,9 +453,9 @@ const datesDayDifference = (date1, date2) => {
 }
 
 ;(async function () {
-  if (document.querySelector('.js-calendar-graph')) {
+  // Are we on a profile page?
+  if (document.querySelector('.vcard-names-container')) {
     await getSettings()
-    generateIsometricChart()
 
     const config = { attributes: true, childList: true, subtree: true }
     const callback = (mutationsList) => {


### PR DESCRIPTION
Fixes #309 

GitHub now seems to load the contribution graph asynchronously and the previous extension hook no longer worked. The change is to look for a different class name on the page to see if we're on a profile page and then rely on the existing `MutationObserver` to wait for the graph to load.