### PR TITLE
Show year so far when clicking on current year

### DIFF
--- a/src/iso.js
+++ b/src/iso.js
@@ -1,6 +1,7 @@
 import { toArray, groupBy, last } from 'lodash-es'
 
 const dateFormat = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+const sameDay = (d1, d2) => d1.toDateString() === d2.toDateString()
 
 let days
 let weeks
@@ -204,7 +205,9 @@ const loadStats = () => {
       firstDay = d.date
     }
 
-    if (days.at(-1) === d) {
+    if (sameDay(d.date, new Date())) {
+      lastDay = d.date
+    } else if (!lastDay && days.at(-1) === d) {
       lastDay = d.date
     }
 


### PR DESCRIPTION
Now, when clicking on the current year, the `lastDay` is set to the current date. This has two impacts:
- The average commit per day is now calculated taking the days in the year so far, instead of the whole year
- The `Jan 1 -> Dec 31` on the total contributions chart is now replaced with a `Jan 1 -> <currentdate>`

![image](https://github.com/user-attachments/assets/28e309d7-4b0f-403e-85a9-10e44206660f)

Closes #316 
