### PR TITLE
fix: sanitize shell/subprocess call in submit.js

### DIFF
--- a/scripts/submit.js
+++ b/scripts/submit.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -55,12 +55,15 @@ async function submitChrome() {
   if (dryRun) {
     console.log('  Validating credentials...')
     // Try to get an access token to validate credentials
-    const tokenResult = execSync(
-      `curl -s -X POST "https://oauth2.googleapis.com/token" \
-        -d "client_id=${process.env.CHROME_CLIENT_ID}" \
-        -d "client_secret=${process.env.CHROME_CLIENT_SECRET}" \
-        -d "refresh_token=${process.env.CHROME_REFRESH_TOKEN}" \
-        -d "grant_type=refresh_token"`,
+    const tokenResult = execFileSync(
+      'curl',
+      [
+        '-s', '-X', 'POST', 'https://oauth2.googleapis.com/token',
+        '-d', `client_id=${process.env.CHROME_CLIENT_ID}`,
+        '-d', `client_secret=${process.env.CHROME_CLIENT_SECRET}`,
+        '-d', `refresh_token=${process.env.CHROME_REFRESH_TOKEN}`,
+        '-d', 'grant_type=refresh_token'
+      ],
       { encoding: 'utf8' }
     )
     const tokenData = JSON.parse(tokenResult)
@@ -179,11 +182,14 @@ async function submitEdge() {
   if (dryRun) {
     console.log('  Validating credentials (v1.1 API)...')
     // Test the v1.1 API by checking the current draft submission
-    const result = execSync(
-      `curl -s -w "\\n%{http_code}" \
-        -H "Authorization: ApiKey ${process.env.EDGE_API_KEY}" \
-        -H "X-ClientID: ${process.env.EDGE_CLIENT_ID}" \
-        "https://api.addons.microsoftedge.microsoft.com/v1/products/${process.env.EDGE_PRODUCT_ID}/submissions/draft/package"`,
+    const result = execFileSync(
+      'curl',
+      [
+        '-s', '-w', '\n%{http_code}',
+        '-H', `Authorization: ApiKey ${process.env.EDGE_API_KEY}`,
+        '-H', `X-ClientID: ${process.env.EDGE_CLIENT_ID}`,
+        `https://api.addons.microsoftedge.microsoft.com/v1/products/${process.env.EDGE_PRODUCT_ID}/submissions/draft/package`
+      ],
       { encoding: 'utf8' }
     )
     const lines = result.trim().split('\n')


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/submit.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/submit.js:55` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The Chrome Web Store submission script directly interpolates environment variables into shell commands using execSync(). If environment variables contain shell metacharacters, they will be interpreted by the shell, enabling command injection. Similar patterns exist in Edge submission paths where API keys are interpolated into curl command strings.

## Evidence

**Exploitation scenario**: An attacker who can set environment variables in the CI/CD pipeline (e.g., via compromised secret, malicious PR modifying workflow env, or misconfigured CI system) can inject shell commands.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/submit.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
